### PR TITLE
Adds class to wrap flex elements

### DIFF
--- a/dist/css/alom.css
+++ b/dist/css/alom.css
@@ -367,15 +367,14 @@ svg:not(:root) {
       justify-content: flex-end; }
     .align-flex.is-column.horizontal {
       -webkit-box-align: center;
-      -ms-grid-row-align: center;
       align-items: center; }
     .align-flex.is-column.horizontal-end {
       -webkit-box-align: end;
-      -ms-grid-row-align: flex-end;
       align-items: flex-end; }
+  .align-flex.wrap {
+    flex-wrap: wrap; }
   .align-flex.vertical:not(.is-column) {
     -webkit-box-align: center;
-    -ms-grid-row-align: center;
     align-items: center; }
     .align-flex.vertical:not(.is-column).end {
       -webkit-box-pack: end;
@@ -385,11 +384,9 @@ svg:not(:root) {
     justify-content: center; }
     .align-flex.horizontal:not(.is-column).end {
       -webkit-box-align: end;
-      -ms-grid-row-align: flex-end;
       align-items: flex-end; }
   .align-flex.center {
     -webkit-box-align: center;
-    -ms-grid-row-align: center;
     align-items: center;
     -webkit-box-pack: center;
     justify-content: center; }

--- a/docs/alom.css
+++ b/docs/alom.css
@@ -367,15 +367,14 @@ svg:not(:root) {
       justify-content: flex-end; }
     .align-flex.is-column.horizontal {
       -webkit-box-align: center;
-      -ms-grid-row-align: center;
       align-items: center; }
     .align-flex.is-column.horizontal-end {
       -webkit-box-align: end;
-      -ms-grid-row-align: flex-end;
       align-items: flex-end; }
+  .align-flex.wrap {
+    flex-wrap: wrap; }
   .align-flex.vertical:not(.is-column) {
     -webkit-box-align: center;
-    -ms-grid-row-align: center;
     align-items: center; }
     .align-flex.vertical:not(.is-column).end {
       -webkit-box-pack: end;
@@ -385,11 +384,9 @@ svg:not(:root) {
     justify-content: center; }
     .align-flex.horizontal:not(.is-column).end {
       -webkit-box-align: end;
-      -ms-grid-row-align: flex-end;
       align-items: flex-end; }
   .align-flex.center {
     -webkit-box-align: center;
-    -ms-grid-row-align: center;
     align-items: center;
     -webkit-box-pack: center;
     justify-content: center; }

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -82,6 +82,10 @@ $displays: 'block', 'flex', 'inline', 'inline-block', 'inline-flex', 'table', 'n
     }
   }
 
+  &.wrap {
+    flex-wrap: wrap;
+  }
+
   &.vertical:not(.is-column) {
     align-items: center;
 


### PR DESCRIPTION
## What does this PR do?

- Adds a class to the `.align-flex` class for wrapping the elements inside them. Example: `class="align-flex wrap"`